### PR TITLE
fix(workflows): trigger on pull request target

### DIFF
--- a/.github/workflows/achievement_update.yml
+++ b/.github/workflows/achievement_update.yml
@@ -1,7 +1,7 @@
 name: Achievement guide update
 
 on:
-  pull_request:
+  pull_request_target:
     paths:
       - 'guides/**'
       - '.utils/achievements.go'


### PR DESCRIPTION
When a workflow is triggered by the pull_request_target event, the GITHUB_TOKEN is granted read/write repository permissions.

source: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

ref: https://github.com/LukoJy3D/perfect100/pull/101